### PR TITLE
Fix improper string escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,13 +125,14 @@ export default function stringifyObject(input, options, pad) {
 		}
 
 		input = String(input).replace(/[\r\n]/g, x => x === '\n' ? '\\n' : '\\r');
+		input = input.replace(/\\/g, '\\\\');
 
 		if (options.singleQuotes === false) {
 			input = input.replace(/"/g, '\\"');
 			return `"${input}"`;
 		}
 
-		input = input.replace(/\\?'/g, '\\\'');
+		input = input.replace(/'/g, '\\\'');
 		return `'${input}'`;
 	})(input, options, pad);
 }


### PR DESCRIPTION
Before, input strings like `'\\'` or `"\\"` were improperly escaped. For double quotes, backslashes were not escaped at all and for single quotes, they were basically ignored (due to `/\\?'/`).

The above examples now produce `'\\'`/`"\\"` instead of `'\'`/`"\"` and are thus valid strings again.